### PR TITLE
Fix for Unused import

### DIFF
--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import pandas as pd
-import plotly.express as px
 import sqlalchemy as sql
 
 from typing import List

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -8,7 +8,6 @@ import plotly.express as px
 import sqlalchemy as sql
 
 from sqlalchemy.engine import Engine
-from typing import List, Union, Optional
 from plotly.graph_objects import Figure
 
 # Add the parent directory to sys.path

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -8,7 +8,6 @@ import plotly.express as px
 import sqlalchemy as sql
 
 from sqlalchemy.engine import Engine
-from sqlalchemy import text
 from typing import List, Union, Optional
 from plotly.graph_objects import Figure
 

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -5,7 +5,6 @@ import sys
 import pandas as pd
 import sqlalchemy as sql
 
-from plotly.graph_objects import Figure
 from typing import List
 
 # Add the parent directory to sys.path

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -6,7 +6,6 @@ import pandas as pd
 import sqlalchemy as sql
 
 from plotly.graph_objects import Figure
-from sqlalchemy.engine import Engine
 from typing import List
 
 # Add the parent directory to sys.path

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -1,14 +1,13 @@
 """This module contains utility functions used in report generation."""
-
 import os
 import sys
 
 import pandas as pd
 import sqlalchemy as sql
 
-from typing import List
-from sqlalchemy.engine import Engine
 from plotly.graph_objects import Figure
+from sqlalchemy.engine import Engine
+from typing import List
 
 # Add the parent directory to sys.path
 sys.path.append(

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import plotly.express as px
 import sqlalchemy as sql
 
+from typing import List
 from sqlalchemy.engine import Engine
 from plotly.graph_objects import Figure
 


### PR DESCRIPTION
Remove the unused import `from sqlalchemy import text` from `report/report_utils.py`.

Best fix without changing behavior:
- Keep `import sqlalchemy as sql` unchanged, since the code already uses `sql.text(...)`.
- Delete only the unused direct import line.
- No other code changes are required, and functionality remains identical.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._