### PR TITLE
Fix for Unused exception object

### DIFF
--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -69,7 +69,7 @@ def hh_metrics(category: str) -> str:
     elif category == "Persons per Household":
         return "Mean Household Size"
     else:
-        ValueError(f"Unknown household category: {category}")
+        raise ValueError(f"Unknown household category: {category}")
 
 
 def life_expectancy(q_x: List[float], age: int) -> int:


### PR DESCRIPTION
To fix this, the exception in `hh_metrics` must be raised rather than merely instantiated.

Best single fix (no functionality change for valid inputs):
- In `report/report_utils.py`, update line 72 in `hh_metrics`:
  - From: `ValueError(f"Unknown household category: {category}")`
  - To: `raise ValueError(f"Unknown household category: {category}")`

This preserves all existing behavior for known categories and correctly fails fast for invalid categories, aligning with the function’s `-> str` contract. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._