### PR TITLE
Fix for Except block handles 'BaseException'

### DIFF
--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -118,8 +118,8 @@ def get_data(data_selector: str, run_id: int | None = None) -> dict:
                 try:
                     df = pd.read_csv(fp)
                     result[dataset] = {True: df}
-                except:
-                    result[dataset] = {False: f"Failed to read CSV: {fp}"}
+                except Exception as e:
+                    result[dataset] = {False: f"Failed to read CSV: {fp}: {e}"}
             else:
                 result[dataset] = {False: f"No CSV exists"}
         elif data_selector == "SQL Database":


### PR DESCRIPTION
Use a specific exception handler (`except Exception as e`) instead of a bare `except:` in `get_data`’s CSV branch.

Best fix (minimal, behavior-preserving):
- In `report/report_utils.py`, within `get_data`, change line 121 from `except:` to `except Exception as e:`.
- Optionally include `e` in the returned error string for better diagnostics, consistent with other handlers in this file.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._