### PR TITLE
Fix for Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -41,6 +41,7 @@ def age_5y(age: float) -> str:
     for age_group, bounds in MAP_5Y_AGE_GROUPS.items():
         if bounds["low"] <= age <= bounds["high"]:
             return age_group
+    raise ValueError(f"Age out of supported range for 5-year grouping: {age}")
 
 
 def hh_metrics(category: str) -> str:

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -69,7 +69,7 @@ def hh_metrics(category: str) -> str:
         return "Pct of Total - Workers"
     elif category == "Persons per Household":
         return "Mean Household Size"
-    else:
+        raise ValueError(f"Unknown household category: {category}")
         ValueError(f"Unknown household category: {category}")
 
 

--- a/report/report_utils.py
+++ b/report/report_utils.py
@@ -69,8 +69,8 @@ def hh_metrics(category: str) -> str:
         return "Pct of Total - Workers"
     elif category == "Persons per Household":
         return "Mean Household Size"
-        raise ValueError(f"Unknown household category: {category}")
-        ValueError(f"Unknown household category: {category}")
+
+    raise ValueError(f"Unknown household category: {category}")
 
 
 def life_expectancy(q_x: List[float], age: int) -> int:


### PR DESCRIPTION
To fix this, ensure `age_5y` has an explicit return behavior for unmatched inputs. The best non-breaking approach is to raise a `ValueError` after the loop when no age group matches. This avoids silently returning `None`, preserves the `-> str` contract, and makes invalid data failures explicit.

Edit only `report/report_utils.py`, in `age_5y` (around lines 39–45): add a final `raise ValueError(...)` after the loop.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._