### PR TITLE
Fix for Unused local variable

### DIFF
--- a/python/input_modules/birth_rates.py
+++ b/python/input_modules/birth_rates.py
@@ -143,14 +143,14 @@ def get_birth_rates(
         # More than one race folded into all categories (overstating all others)
         if 2010 <= yr <= 2017:
             avg_rates = (
-                birth_rates.groupby(["sex", "age"]).agg({"rate": "mean"}).reset_index()
+                rates.groupby(["sex", "age"]).agg({"rate": "mean"}).reset_index()
             )
 
             avg_rates["race"] = "More than one race"
-            birth_rates = pd.concat([birth_rates, avg_rates])
+            rates = pd.concat([rates, avg_rates])
 
             avg_rates["race"] = "Native Hawaiian or Other Pacific Islander alone"
-            birth_rates = pd.concat([birth_rates, avg_rates])
+            rates = pd.concat([rates, avg_rates])
         else:
             pass
 


### PR DESCRIPTION
The fix is to consistently use `rates` in the 2010–2017 adjustment block, since `rates` is the DataFrame created earlier and the one returned by the function.

Best fix in this snippet:
- In `python/input_modules/birth_rates.py`, within `get_birth_rates`, replace references to `birth_rates` with `rates` on lines 146, 150, and 153.
- This preserves functionality intent (augmenting rates for missing race categories in 2010–2017) and ensures the adjusted data is actually what gets returned.
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._