### PR TITLE
[PULL REQUEST] Add Input Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Set the configuration file **config.yml** parameters specific to the model run o
 ## Configuration File Settings
 *Note that the configuration file contains datasets stored on a SQL server instance accessed at runtime through queries. It is possible to provide query results as local datasets and migrate the SQL datasets to the **csv** section of the configuration file to remove the dependency on the SQL instance.*
 ```yaml
-version: "v0.0.1"
+version: "0.0.0-dev"
 comments: "No Comments" # Add comments pertaining to the run
 configurations:  # other configuration files
   rates_map: "rates_map.yml"  # local birth/death rate files mapping

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-version: "v0.0.1"
+version: "0.0.0-dev"
 comments: "No Comments"
 configurations:
   rates_map: "rates_map.yml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.0"  # not used
 requires-python = ">=3.14"
 dependencies = [
     "black>=26.5.1,<27.0.0",
+    "cerberus>=1.3.8,<2.0.0",
     "numpy>=2.4.6,<3.0.0",
     "openpyxl>=3.1.5,<4.0.0",
     "pandas>=3.0.3,<4.0.0",

--- a/python/input_modules/migration_rates.py
+++ b/python/input_modules/migration_rates.py
@@ -114,26 +114,6 @@ def calculate_migration_rates(
     return df[["race", "sex", "age", "rate_in", "rate_out"]]
 
 
-def check_migration_controls(yr: int) -> pd.DataFrame:
-    """Check migration control totals."""
-    # Ensure controls DataFrame contains required columns
-    required_cols = {"year", "ins", "outs"}
-    if not required_cols.issubset(utils.MIGRATION_CONTROLS.columns):
-        raise ValueError("Migration controls must contain columns: (year, ins, outs)")
-
-    # Check if increment year is provided in control totals and filter
-    if yr not in utils.MIGRATION_CONTROLS["year"].unique():
-        raise ValueError(f"Increment year {yr} not provided in migration controls")
-    else:
-        controls = utils.MIGRATION_CONTROLS.loc[utils.MIGRATION_CONTROLS["year"] == yr]
-
-    # Check control totals are >= 0
-    if controls["ins"].sum() < 0 or controls["outs"].sum() < 0:
-        raise ValueError(f"Migration control totals for increment year {yr} are <0")
-
-    return controls
-
-
 def control_migration_rates(
     yr: int,
     pop_df: pd.DataFrame,
@@ -165,7 +145,7 @@ def control_migration_rates(
         raise ValueError("cap_rates parameter must be between 0 and 1")
 
     # Check the controls DataFrame is valid and return controls for the given year
-    controls = check_migration_controls(yr=yr)
+    controls = utils.MIGRATION_CONTROLS.loc[utils.MIGRATION_CONTROLS["year"] == yr]
 
     # Calculate the total in/out migrants from the rates and population
     # Note this uses the civilian population as opposed to the survived civilian population

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -1,0 +1,203 @@
+import cerberus
+import yaml
+
+import pandas as pd
+
+
+class InputParser:
+    """A class to parse and validate input configurations.
+
+    Attributes:
+        _config (dict): The configuration dictionary to be parsed
+        base_year (int): Used to store the base year of a new run
+        launch_year (int): Used to store the launch year of a new run
+        horizon_year (int): Used to store the horizon year of a new run
+        version (str): The software version of the current run
+        comments (str): Any comments associated with the current run
+        rates_map (dict): Mapping of local birth rate data files for each year
+            and race/ethnicity category
+        controls (dict): Mapping of control totals for each year
+        migration_controls (pd.DataFrame | None): Optional migration control totals (ins/outs)
+            for each post-launch increment year. If not provided, set to None.
+        load_to_database (bool): Whether to load the run results into a database.
+
+    Methods:
+        parse_config(): Control function
+        _validate_config(): Validate the configuration file
+        _parse_years(): Parses the run launch and horizon years from the configuration
+            file and sets the base year
+        _parse_rates_map(): Parses the rates mapping from the configuration file and
+            sets the rates_map attribute
+        _parse_controls(): Parses the controls mapping from the configuration file and
+            sets the controls attribute
+        _parse_migration_controls(): Parses the migration controls mapping from the
+            configuration file and sets the migration_controls attribute
+    """
+
+    def __init__(self, config: dict) -> None:
+        """Initialize the InputParser with a configuration dictionary."""
+        self._config = config
+        self.base_year = None
+        self.launch_year = None
+        self.horizon_year = None
+        self.version = None
+        self.comments = None
+        self.rates_map = {}
+        self.controls = {}
+        self.migration_controls = None
+        self.load_to_database = None
+
+    def parse_config(self) -> None:
+        """Control flow to parse the runtime configuration.
+
+        First, the contents of the configuration file are validated. Then, the
+        base, launch, and horizon years are set along with the software version
+        and any comments. Finally, the birth rates mapping, controls totals,
+        and optional migration control totals are parsed and set."""
+        self._validate_config()
+        _interval = self._parse_interval()
+        self.base_year = _interval["base_year"]
+        self.launch_year = _interval["launch_year"]
+        self.horizon_year = _interval["horizon_year"]
+        self.comments = self._config.get("comments")
+        self.version = self._config.get("version")
+        self.rates_map = self._parse_rates_map()
+        self.controls = self._parse_controls()
+        self.migration_controls = self._parse_migration_controls()
+        self.load_to_database = self._config.get("sql", {}).get(
+            "load_to_database", False
+        )
+
+    def _validate_config(self) -> None:
+        """Validate the contents of the configuration dictionary."""
+        # Check all keys are present and key types using Cerberus. For help, see their
+        # website here: https://docs.python-cerberus.org/usage.html
+        schema = {
+            "version": {"type": "string", "allowed": ["0.0.0-dev"]},
+            "comments": {"type": "string"},
+            "configurations": {
+                "type": "dict",
+                "schema": {
+                    "rates_map": {"type": "string"},
+                    "controls": {"type": "string"},
+                },
+            },
+            "csv": {
+                "type": "dict",
+                "schema": {"migration_controls": {"type": "string", "nullable": True}},
+            },
+            "interval": {
+                "type": "dict",
+                "schema": {
+                    "launch": {"type": "integer", "min": 2010, "max": 2025},
+                    "horizon": {"type": "integer", "min": 2011},
+                },
+            },
+            "sql": {
+                "type": "dict",
+                "schema": {"load_to_database": {"type": "boolean"}},
+            },
+        }
+
+        validator = cerberus.Validator(schema, require_all=True)
+        if not validator.validate(self._config):
+            raise ValueError(validator.errors)
+
+    def _parse_interval(self) -> dict:
+        """Parse the base, launch, and horizon years from the configuration file."""
+        launch_year = self._config["interval"]["launch"]
+        horizon_year = self._config["interval"]["horizon"]
+
+        # Ensure launch year is less than horizon year
+        if launch_year >= horizon_year:
+            raise ValueError("Launch year must be less than horizon year")
+
+        if 2020 <= launch_year <= 2029:
+            base_year = 2020
+        else:
+            raise ValueError("""
+                    Only base year 2020 is supported at this time.
+                    Launch year must be between 2020 and 2029.
+                """)
+
+        return {
+            "base_year": base_year,
+            "launch_year": launch_year,
+            "horizon_year": horizon_year,
+        }
+
+    def _parse_rates_map(self) -> dict:
+        """Parse the rates mapping from the configuration file."""
+        # Check the rates mapping file exists and is a valid YAML file
+        rates_map_fp = self._config["configurations"]["rates_map"]
+        try:
+            with open(rates_map_fp, "r") as f:
+                rates_map = yaml.safe_load(f)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Rates map file not found: {rates_map_fp}")
+        except yaml.YAMLError as e:
+            raise ValueError(f"Error parsing rates map YAML file: {e}")
+
+        # TODO: Normally we would validate the schema but this is soon to be removed.
+
+        return rates_map
+
+    def _parse_controls(self) -> dict:
+        """Parse the controls mapping from the configuration file."""
+        # Check the controls mapping file exists and is a valid YAML file
+        controls_fp = self._config["configurations"]["controls"]
+        try:
+            with open(controls_fp, "r") as f:
+                controls = yaml.safe_load(f)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Controls file not found: {controls_fp}")
+        except yaml.YAMLError as e:
+            raise ValueError(f"Error parsing controls YAML file: {e}")
+
+        # TODO: Normally we would validate the schema but this is soon to be removed.
+
+        return controls
+
+    def _parse_migration_controls(self) -> pd.DataFrame | None:
+        """Parse the migration controls CSV file from the configuration file."""
+        # Check the migration controls file exists and is a valid CSV file
+        migration_controls_fp = self._config["csv"].get("migration_controls")
+        if migration_controls_fp is None:
+            return None
+        try:
+            with open(migration_controls_fp, "r") as f:
+                migration_controls = pd.read_csv(f)
+        except FileNotFoundError:
+            raise FileNotFoundError(
+                f"Migration controls file not found: {migration_controls_fp}"
+            )
+        except pd.errors.ParserError as e:
+            raise ValueError(f"Error parsing migration controls CSV file: {e}")
+
+        # Ensure DataFrame contains required columns
+        required_cols = {"year", "ins", "outs"}
+        if not required_cols.issubset(migration_controls.columns):
+            raise ValueError(
+                "Migration controls must contain columns: (year, ins, outs)"
+            )
+
+        # Check control totals are >= 0
+        if any(migration_controls["ins"] < 0) or any(migration_controls["outs"] < 0):
+            raise ValueError("Migration control totals must be >= 0")
+
+        # Check for duplicate years in migration controls
+        if migration_controls["year"].duplicated().any():
+            raise ValueError("Duplicate years found in migration controls")
+
+        # Check that all years in migration controls are post-launch years
+        post_launch_years = range(self.launch_year + 1, self.horizon_year + 1)  # type: ignore
+        if not all(year in post_launch_years for year in migration_controls["year"]):
+            raise ValueError("Migration controls must only contain post-launch years")
+
+        # Check that all post-launch years are present in migration controls
+        if not all(
+            year in migration_controls["year"].values for year in post_launch_years
+        ):
+            raise ValueError("Migration controls must contain all post-launch years")
+
+        return migration_controls

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -1,4 +1,5 @@
 import cerberus
+import pathlib
 import yaml
 
 import pandas as pd
@@ -132,7 +133,9 @@ class InputParser:
         rates_map_fp = self._config["configurations"]["rates_map"]
         rates_map_path = pathlib.Path(rates_map_fp)
         if not rates_map_path.is_absolute():
-            rates_map_path = pathlib.Path(__file__).resolve().parent.parent / rates_map_path
+            rates_map_path = (
+                pathlib.Path(__file__).resolve().parent.parent / rates_map_path
+            )
         try:
             with open(rates_map_path, "r") as f:
                 rates_map = yaml.safe_load(f)
@@ -151,7 +154,9 @@ class InputParser:
         controls_fp = self._config["configurations"]["controls"]
         controls_path = pathlib.Path(controls_fp)
         if not controls_path.is_absolute():
-            controls_path = pathlib.Path(__file__).resolve().parent.parent / controls_path
+            controls_path = (
+                pathlib.Path(__file__).resolve().parent.parent / controls_path
+            )
         try:
             with open(controls_path, "r") as f:
                 controls = yaml.safe_load(f)

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -146,8 +146,11 @@ class InputParser:
         """Parse the controls mapping from the configuration file."""
         # Check the controls mapping file exists and is a valid YAML file
         controls_fp = self._config["configurations"]["controls"]
+        controls_path = pathlib.Path(controls_fp)
+        if not controls_path.is_absolute():
+            controls_path = pathlib.Path(__file__).resolve().parent.parent / controls_path
         try:
-            with open(controls_fp, "r") as f:
+            with open(controls_path, "r") as f:
                 controls = yaml.safe_load(f)
         except FileNotFoundError:
             raise FileNotFoundError(f"Controls file not found: {controls_fp}")

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -164,8 +164,14 @@ class InputParser:
         migration_controls_fp = self._config["csv"].get("migration_controls")
         if migration_controls_fp is None:
             return None
+
+        migration_controls_path = pathlib.Path(migration_controls_fp)
+        if not migration_controls_path.is_absolute():
+            migration_controls_path = (
+                pathlib.Path(__file__).resolve().parent.parent / migration_controls_path
+            )
         try:
-            with open(migration_controls_fp, "r") as f:
+            with open(migration_controls_path, "r") as f:
                 migration_controls = pd.read_csv(f)
         except FileNotFoundError:
             raise FileNotFoundError(

--- a/python/parsers.py
+++ b/python/parsers.py
@@ -130,8 +130,11 @@ class InputParser:
         """Parse the rates mapping from the configuration file."""
         # Check the rates mapping file exists and is a valid YAML file
         rates_map_fp = self._config["configurations"]["rates_map"]
+        rates_map_path = pathlib.Path(rates_map_fp)
+        if not rates_map_path.is_absolute():
+            rates_map_path = pathlib.Path(__file__).resolve().parent.parent / rates_map_path
         try:
-            with open(rates_map_fp, "r") as f:
+            with open(rates_map_path, "r") as f:
                 rates_map = yaml.safe_load(f)
         except FileNotFoundError:
             raise FileNotFoundError(f"Rates map file not found: {rates_map_fp}")

--- a/python/utils.py
+++ b/python/utils.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 import sqlalchemy as sql
 
+import python.parsers as parsers
+
 #########
 # PATHS #
 #########
@@ -68,37 +70,36 @@ SQL_ENGINE = sql.create_engine(
 #########################
 # RUNTIME CONFIGURATION #
 #########################
+
+# Load configuration YAML file
 try:
     with open(ROOT_FOLDER / "config.yml", "r") as file:
         config = yaml.safe_load(file)
-    for k, v in config["configurations"].items():
-        with open(ROOT_FOLDER / v, "r") as configurations_file:
-            config["configurations"][k] = yaml.safe_load(configurations_file)
 except IOError:
     raise IOError("config.yml does not exist, see README.md")
 
-# TODO: Add input configuration parser
+# Initialize input parser
+# Parse the configuration file and validate its contents
+input_parser = parsers.InputParser(config=config)
+input_parser.parse_config()
 
 # Get data from the parsed and validated configuration file
-VERSION = config["version"]
-COMMENTS = config["comments"]
+BASE_YEAR = input_parser.base_year
+LAUNCH_YEAR = input_parser.launch_year
+HORIZON_YEAR = input_parser.horizon_year
+VERSION = input_parser.version
+COMMENTS = input_parser.comments
+RATES_MAP = input_parser.rates_map
+CONTROLS = input_parser.controls
+MIGRATION_CONTROLS = input_parser.migration_controls
+LOAD_TO_DATABASE = input_parser.load_to_database
 
-LAUNCH_YEAR = config["interval"]["launch"]
-if 2020 <= LAUNCH_YEAR < 2030:
-    BASE_YEAR = 2020
-else:
-    raise ValueError("Invalid launch year provided. Must be between 2020 and 2029.")
-HORIZON_YEAR = config["interval"]["horizon"]
+logger.info(
+    f"Runtime configuration loaded: launch_year={LAUNCH_YEAR}, horizon_year={HORIZON_YEAR}"
+)
 
-RATES_MAP = config["configurations"]["rates_map"]
-CONTROLS = config["configurations"]["controls"]
-
-if config["csv"]["migration_controls"] is not None:
-    MIGRATION_CONTROLS = pd.read_csv(ROOT_FOLDER / config["csv"]["migration_controls"])
-else:
-    MIGRATION_CONTROLS = None
-
-LOAD_TO_DATABASE = config["sql"]["load_to_database"]
+if MIGRATION_CONTROLS is not None:
+    logger.info("Migration controls loaded from configuration file")
 
 
 ##############################

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cerberus"
+version = "1.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/cf/845d32e330e49e34f1a22dc44868750e75485d7c08c07d37795bcf0a780e/cerberus-1.3.8.tar.gz", hash = "sha256:579554887ffd189226774b87570f4a76db75cf0efcbaffcacd5e98b8ee877f61", size = 29660, upload-time = "2025-11-06T18:29:40.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/00/ff53f3a4d51e64e9137ce2408a43edf18fec96eebb61f87a6598578fa563/cerberus-1.3.8-py3-none-any.whl", hash = "sha256:46c029e3e2a4735408ed36bec14ef2cbf3e50d8ebe47fb34ee1e54b2da814df2", size = 30567, upload-time = "2025-11-06T18:29:38.815Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +145,7 @@ version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "black" },
+    { name = "cerberus" },
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -150,6 +160,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "black", specifier = ">=26.5.1,<27.0.0" },
+    { name = "cerberus", specifier = ">=1.3.8,<2.0.0" },
     { name = "numpy", specifier = ">=2.4.6,<3.0.0" },
     { name = "openpyxl", specifier = ">=3.1.5,<4.0.0" },
     { name = "pandas", specifier = ">=3.0.3,<4.0.0" },


### PR DESCRIPTION
### Describe this pull request. What changes are being made?
Adds an input configuration file parser to the project.

- The input parser is defined in the `python/parsers.py` file and then used to set project constants in the `python/utils.py`
- The parser validates the schema of the `config.yml`, checks the launch and horizon years are valid, sets the base year, and loads and checks the optional migration controls file is valid
- The rate mapping and controls YAML files do not have their schemas validated as they will disappear once #140 is complete

The version was also updated to align with the semantic versioning strategy of https://github.com/SANDAG/Estimates-Program

### Validation and testing
Multiple local runs were made from 2020-2025 with and without migration control totals asserted.
Tested various incorrect specifications of the configuration and migration controls files.
Would suggest the PR reviewer test out incorrect specifications of the configuration and migration controls files.

### What issues does this pull request address?
closes #151

### Additional context
Follows same structure as https://github.com/SANDAG/Estimates-Program/blob/main/python/parsers.py
